### PR TITLE
Fix Paraview 6.0 GenerateSurfaceNormals warning

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -113,7 +113,7 @@ jobs:
             --exclude=.git \
             --exclude=.github \
             .
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: github-pages
           path: docs/_build/html.tar

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -23,7 +23,7 @@ configuration files and data available in the container (see [Usage](usage)).
 
 ## Option 2: Native environment
 
-1. Install ParaView (v5.10 or above). You can
+1. Install ParaView (v5.13 or above). You can
    [download a pre-built binary](https://www.paraview.org/download/)
    or use [Spack](https://spack.readthedocs.io/en/latest/) to compile it from
    source. For example, download ParaView 6.0 for a Linux machine like this:

--- a/gwpv/render/frames.py
+++ b/gwpv/render/frames.py
@@ -404,7 +404,7 @@ def render_frames(
             # Try to make horizon surfaces smooth. At low angular resoluton
             # they still show artifacts, so perhaps more can be done.
             horizon = pv.ExtractSurface(Input=horizon)
-            horizon = pv.GenerateSurfaceNormals(Input=horizon)
+            horizon = pv.SurfaceNormals(Input=horizon)
             horizon_rep_config = horizon_config.get("Representation", {})
             if "Representation" not in horizon_rep_config:
                 horizon_rep_config["Representation"] = "Surface"


### PR DESCRIPTION
Fixes the warning below when rendering.

`SurfaceNormals` was introduced in Paraview 5.13 so I updated the documentation to recommend from this version. Also changed the version of `actions/upload-artifact` to a non-deprecated version so hopefully the docs will build with the updated instructions.

```
(  10.086s) [paraview        ]         vtkSMProxy.cxx:888   WARN| vtkSMSourceProxy (0x1cd1c490): Proxy (filters, PolyDataNormals)  has been deprecated in ParaView 5.13 and will be removed by ParaView 6.1. 
        This has been renamed into 'SurfaceNormals'. Please consider using that instead.
```

@nilsvu